### PR TITLE
Add a Copy button to quickly copy the WKT

### DIFF
--- a/getwkt3_dialog.py
+++ b/getwkt3_dialog.py
@@ -25,6 +25,9 @@ import os
 
 from PyQt5 import uic
 from PyQt5 import QtWidgets
+from PyQt5.QtWidgets import QApplication
+from qgis.core import Qgis
+from qgis.utils import iface
 
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
     os.path.dirname(__file__), 'getwkt3_dialog_base.ui'))
@@ -36,7 +39,19 @@ class getwkt3Dialog(QtWidgets.QDialog, FORM_CLASS):
         super(getwkt3Dialog, self).__init__(parent)
         self.setupUi(self)
         self.pushButton.clicked.connect(self.handleHide)
+        self.copyButton.clicked.connect(self.copyAndHide)
 
     def handleHide(self):
         """Hide handle"""
         self.hide()
+
+    def copyAndHide(self):
+        """Copy the WKT content and close"""
+        clipboard = QApplication.clipboard()
+        wkt_text = self.wktTextEdit.toPlainText()
+        if "ERROR" in wkt_text:
+            iface.messageBar().pushMessage("Get WKT", "There is no WKT to copy!", level=Qgis.Warning, duration=5)
+            return
+        clipboard.setText(wkt_text)
+        iface.messageBar().pushMessage("Get WKT", "WKT copied to clipboard", level=Qgis.Info, duration=5)
+        self.handleHide()

--- a/getwkt3_dialog_base.ui
+++ b/getwkt3_dialog_base.ui
@@ -28,6 +28,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="copyButton">
+       <property name="text">
+        <string>Copy &amp;&amp; close</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="pushButton">
        <property name="text">
         <string>OK</string>


### PR DESCRIPTION
Adds a button to copy the WKT to clipboard. I've been using this for some time locally and decided to share with others.

![image](https://user-images.githubusercontent.com/10479845/215802484-af75bef9-49e1-402f-9a52-e8f7b7fbbfb7.png)

After copying the following message appears for a few seconds:
![image](https://user-images.githubusercontent.com/10479845/215802592-64e1f01d-9829-4053-bc5d-4866898828e7.png)

If there is error, the copy doesn't execute and a warning appears:
![image](https://user-images.githubusercontent.com/10479845/215803167-21856b9d-1ab9-40b3-8ae2-74f2f66639cd.png)

Hope it will be useful for others.