### PR TITLE
Use layer's EPSG code for EWKT string, if not set to reproject

### DIFF
--- a/getwkt3.py
+++ b/getwkt3.py
@@ -348,7 +348,17 @@ class getwkt3:
                 wkt = geom.asWkt(dp_count) if not dp_count is None else geom.asWkt()
             wkt = self.standardise_wkt(wkt)
             if out_type == 'ewkt':
-                text = 'SRID={0};{1}'.format(out_srs_epsg, wkt)
+                ewkt_epsg = out_srs_epsg
+                # if the output EPSG is set to not reproject (-1), try to get the EPSG from the layer instead
+                if ewkt_epsg == -1:
+                    try:
+                        authid = in_srs.authid()
+                        auth, ewkt_epsg = authid.split(':')
+                        if auth != 'EPSG':
+                            ewkt_epsg = -1
+                    except Exception:
+                        ewkt_epsg = -1
+                text = 'SRID={0};{1}'.format(ewkt_epsg, wkt)
             else:
                 text = wkt.upper()
         elif out_type == 'json':


### PR DESCRIPTION
Since 1.7, the default behaviour of the GetEWKT gives the SRID as -1, which is not a valid output code. This change gets the actual EPSG from the layer, as per the old behaviour, if the user hasn't configured a custom EPSG to reproject to.